### PR TITLE
Add /etc description

### DIFF
--- a/linux/etc/opt/page.clip
+++ b/linux/etc/opt/page.clip
@@ -1,0 +1,4 @@
+# /etc/opt
+
+> Configuration for /opt
+> More information: https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch03s07.html

--- a/linux/etc/page.clip
+++ b/linux/etc/page.clip
@@ -1,0 +1,4 @@
+# /etc
+
+> Host-specific system configuration
+> More information: https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch03s07.html


### PR DESCRIPTION
Files and subdirectories those can or can not exist are not listed, just mandatory things are listed (for now).